### PR TITLE
Add x25519 key to default document

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infra-did-js",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "InfraBlockchain DID library creating and managing DIDs",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",
@@ -15,6 +15,9 @@
     "src",
     "LICENSE"
   ],
+  "engines": {
+    "node": ">=18.14"
+  },
   "author": "Bezalel Lim <bezalel@infrablockchain.com>",
   "contributors": [
     {

--- a/src/infra-ss58/index.ts
+++ b/src/infra-ss58/index.ts
@@ -352,8 +352,12 @@ export class InfraSS58 {
     resolve: async (didUrl) => this.getDocument(didUrl)
   }
   static resolve(did: string) {
-    did = did.split('#')[0];
-    return InfraSS58.defaultDocuments(did);
+    try {
+      did = did.split('#')[0];
+      return InfraSS58.defaultDocuments(did);
+    } catch (error) { 
+      throw new Error("Maybe the DID is not valid or not ed25519 address. Please check the DID and try again.")
+    }
   }
   public async getDocument(did, getBbsPlusSigKeys = true) {
     did = did.split('#')[0];

--- a/src/infra-ss58/modules/did.ts
+++ b/src/infra-ss58/modules/did.ts
@@ -1,8 +1,7 @@
-import { u8aToHex } from "@polkadot/util";
+import { u8aToHex, hexToU8a } from "@polkadot/util";
 import { randomAsHex } from "@polkadot/util-crypto";
 import { Codec, DidKey_SS58, BTreeSet, IConfig_SS58, KeyringPair, PublicKey_SS58, ServiceEndpointType, VerificationRelationship, DIDSet } from "../ss58.interface";
-import type { InfraSS58 } from "..";
-
+import { CryptoHelper, type InfraSS58 } from "..";
 
 export class InfraSS58_DID {
 
@@ -61,6 +60,15 @@ export class InfraSS58_DID {
   async registerDIDOnChain(did: string, didKey, controllerDID?: string) {
     const hexId = this.that.didToHexPk(did);
     const didKeys = [didKey].map((d) => d.toJSON ? d.toJSON() : d);
+    const xPk = CryptoHelper.edToX25519Pk(hexToU8a(didKey.publicKey.toJSON()['Ed25519']), 'u8a') as Uint8Array;
+    // Add the X25519 key to the didKeys
+    didKeys.push({
+      publicKey: {
+        X25519: u8aToHex(xPk)
+      },
+      verRels: 0b1000
+    });
+
     //@ts-ignore
     const controllers = new BTreeSet();
     controllers.add(this.that.didToHexPk(controllerDID) as unknown as Codec)


### PR DESCRIPTION
# Overview

See #19 

* Set required node version to `18.14`, because dependencies of this library need node version minimum `18.14`

# Changes

* Add X25519 keyAgreement key in defaultDocument 
```typescript
        {
          id: `${did}#keys-4`,
          type: 'JsonWebKey2020',
          controller: did,
          publicKeyJwk: { ...xPkJwk, alg: undefined }
        },
      ],
      authentication: [`${did}#keys-1`, `${did}#keys-2`, `${did}#keys-3`],
      assertionMethod: [`${did}#keys-1`, `${did}#keys-2`, `${did}#keys-3`],
      keyAgreement: [`${did}#keys-4`],
```

* Handle X25519 key in OnChain storage
```typescript
          if(...){
              ...
          }
          else if (pkObj.x25519) {
            const publicKeyRaw = hexToU8a(pkObj.x25519);
            keys.push(
              [index, "X25519JsonWebKey2020", publicKeyRaw],
            );
          }

          const vr = new VerificationRelationship(dk.verRels.toNumber());
          if (vr.isKeyAgreement()) keyAgr.push(index);

// ========== snip ========== 
     switch (typ) {
        ...
        case "X25519JsonWebKey2020":
          return {
            id: `${id}#keys-${index}`,
            type: "JsonWebKey2020",
            controller: id,
            publicKeyJwk: {
              kty: 'OKP',
              crv: 'X25519',
              kid: `keys-${index}`,
              x: Buffer.from(publicKeyRaw).toString('base64url'),
            }
          }
        ...
       }
```

* Add static resolve function for returning default DID Document in `InfraSS58` class
    * this function can use without did chain
```typescript
  static resolve(did: string) {
    did = did.split('#')[0];
    return InfraSS58.defaultDocuments(did);
  }
```

Closed #19 